### PR TITLE
fix: update run_tests for windows

### DIFF
--- a/dist/platforms/windows/run_tests.ps1
+++ b/dist/platforms/windows/run_tests.ps1
@@ -65,7 +65,7 @@ foreach ( $platform in ${env:TEST_PLATFORMS}.Split(";") )
         Write-Output "#   Building Standalone   #"
         Write-Output "###########################"
         Write-Output ""
-  
+
         # Create directories if they do not exist
         if(-Not (Test-Path -Path $UNITY_PROJECT_PATH\Assets\Editor))
         {
@@ -85,7 +85,7 @@ foreach ( $platform in ${env:TEST_PLATFORMS}.Split(";") )
         # Verify recursive paths
         Get-ChildItem -Path $UNITY_PROJECT_PATH\Assets\Editor -Recurse
         Get-ChildItem -Path $UNITY_PROJECT_PATH\Assets\Player -Recurse
-    
+
         $runTests="-runTests -testPlatform StandaloneWindows64 -builtTestRunnerPath $UNITY_PROJECT_PATH\Build\UnityTestRunner-Standalone.exe"
     }
     else
@@ -111,7 +111,6 @@ foreach ( $platform in ${env:TEST_PLATFORMS}.Split(";") )
                                 -Wait `
                                 -PassThru `
                                 -ArgumentList  "-batchmode `
-                                                -nographics `
                                                 -logFile $FULL_ARTIFACTS_PATH\$platform.log `
                                                 -projectPath $UNITY_PROJECT_PATH `
                                                 -coverageResultsPath $FULL_COVERAGE_RESULTS_PATH `
@@ -131,7 +130,7 @@ foreach ( $platform in ${env:TEST_PLATFORMS}.Split(";") )
     {
         # Code Coverage currently only supports code ran in the Editor and not in Standalone/Player.
         # https://docs.unity.cn/Packages/com.unity.testtools.codecoverage@1.1/manual/TechnicalDetails.html#how-it-works
-        
+
         $TEST_OUTPUT = Start-Process -NoNewWindow -Wait -PassThru "$UNITY_PROJECT_PATH\Build\UnityTestRunner-Standalone.exe" -ArgumentList "-batchmode -nographics -logFile $FULL_ARTIFACTS_PATH\$platform-player.log -testResults $FULL_ARTIFACTS_PATH\$platform-results.xml"
 
         # Catch exit code


### PR DESCRIPTION
#### Changes

- removes the `-nographics` param to match the ubuntu test runner

#### Related Issues

- ...

#### Related PRs

- ...

#### Successful Workflow Run Link

PRs don't have access to secrets so you will need to provide a link to a successful run
of the workflows from your own repo.

- ...

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Docs (If new inputs or outputs have been added or changes to behavior that should be documented. Please make a PR
      in the [documentation repo](https://github.com/game-ci/documentation))
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
